### PR TITLE
DBR_VFIELD

### DIFF
--- a/.ci-local/defaults.set
+++ b/.ci-local/defaults.set
@@ -3,3 +3,5 @@ BASE_DIRNAME=base
 BASE_REPONAME=epics-base
 BASE_REPOOWNER=epics-base
 BASE_VARNAME=EPICS_BASE
+# skip PVA modules for speed
+BASE_RECURSIVE=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 compiler: gcc
-dist: xenial
+dist: bionic
 
 cache:
   directories:
@@ -31,6 +31,8 @@ script:
 
 jobs:
   include:
+  - env: BASE=7.0 EXTRA='CMD_CXXFLAGS=-std=c++11 -Wall -Werror'
+
   - env: BASE=7.0 BCFG=static
 
   - env: BASE=7.0
@@ -41,8 +43,6 @@ jobs:
 
   - env: BASE=7.0
     compiler: clang
-
-  - env: BASE=7.0 EXTRA="CMD_CXXFLAGS=-std=c++11"
 
   - env: BASE=7.0
     dist: trusty

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir)
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 testApp_DEPEND_DIRS += coreApp
 sigApp_DEPEND_DIRS += coreApp
+demoApp_DEPEND_DIRS += coreApp
 
 include $(TOP)/configure/RULES_TOP
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -36,3 +36,6 @@ USR_CPPFLAGS += -DUSE_TYPED_RSET
 
 ## Uncomment to build sigApp/
 #USE_FFTW = YES
+
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/coreApp/src/Makefile
+++ b/coreApp/src/Makefile
@@ -21,6 +21,7 @@ pscCore_SRCS += devPSCWf.cpp
 pscCore_SRCS += devPSCReg.cpp
 pscCore_SRCS += devPSCSingle.cpp
 pscCore_SRCS += devPSCCtrl.cpp
+pscCore_SRCS += devPSCSV.cpp
 
 pscCore_SYS_LIBS += event_core event_extra
 pscCore_SYS_LIBS_Linux += event_pthreads

--- a/coreApp/src/Makefile
+++ b/coreApp/src/Makefile
@@ -22,6 +22,7 @@ pscCore_SRCS += devPSCReg.cpp
 pscCore_SRCS += devPSCSingle.cpp
 pscCore_SRCS += devPSCCtrl.cpp
 pscCore_SRCS += devPSCSV.cpp
+pscCore_SRCS += devPSCPVI.cpp
 
 pscCore_SYS_LIBS += event_core event_extra
 pscCore_SYS_LIBS_Linux += event_pthreads

--- a/coreApp/src/Makefile
+++ b/coreApp/src/Makefile
@@ -22,12 +22,6 @@ pscCore_SRCS += devPSCReg.cpp
 pscCore_SRCS += devPSCSingle.cpp
 pscCore_SRCS += devPSCCtrl.cpp
 
-INC += psc/device.h
-INC += psc/evbase.h
-INC += psc/cblist.h
-INC += psc/util.h
-INC += psc/devcommon.h
-
 pscCore_SYS_LIBS += event_core event_extra
 pscCore_SYS_LIBS_Linux += event_pthreads
 

--- a/coreApp/src/devPSCCtrl.cpp
+++ b/coreApp/src/devPSCCtrl.cpp
@@ -189,7 +189,7 @@ long write_bo_send_changed(boRecord* prec)
         Guard g(psc->lock);
 
         if(!psc->isConnected())
-            recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
+            recGblSetSevrMsg(prec, WRITE_ALARM, INVALID_ALARM, "No Conn");
         else
             psc->flushSend();
 
@@ -206,7 +206,7 @@ long write_lo_send_block(longoutRecord* prec)
         Guard g(psc->lock);
 
         if(prec->val < 0 || prec->val > 0xffff) {
-            recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
+            recGblSetSevrMsg(prec, WRITE_ALARM, INVALID_ALARM, "VAL Out of range");
         } else {
             psc->send(prec->val);
         }

--- a/coreApp/src/devPSCCtrl.cpp
+++ b/coreApp/src/devPSCCtrl.cpp
@@ -18,14 +18,12 @@
 #include <stringinRecord.h>
 
 recAlarm::recAlarm()
-    :std::exception()
-    ,status(COMM_ALARM)
+    :status(COMM_ALARM)
     ,severity(INVALID_ALARM)
 {}
 
 recAlarm::recAlarm(short sts, short sevr)
-    :std::exception()
-    ,status(sts)
+    :status(sts)
     ,severity(sevr)
 {}
 

--- a/coreApp/src/devPSCPVI.cpp
+++ b/coreApp/src/devPSCPVI.cpp
@@ -1,0 +1,131 @@
+/*************************************************************************\
+* Copyright (c) 2014 Brookhaven Science Assoc. as operator of
+      Brookhaven National Laboratory.
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "psc/devcommon.h"
+
+#include <stdio.h>
+#include <arpa/inet.h>
+
+#include <pv/standardField.h>
+
+#include <menuFtype.h>
+#include <pvstructinRecord.h>
+
+namespace {
+
+namespace pvd = epics::pvData;
+
+const pvd::StructureConstPtr ptyp = pvd::getStandardField()->scalarArray(pvd::pvDouble, "alarm,timeStamp");
+
+template<int dir>
+long init_pvi_record(pvstructinRecord* prec)
+{
+    assert(prec->inp.type==INST_IO);
+    try {
+        std::auto_ptr<Priv> priv(new Priv(prec));
+
+        prec->val = ptyp->build();
+
+        parse_link(priv.get(), prec->inp.value.instio.string, dir);
+
+        prec->dpvt = (void*)priv.release();
+
+    }CATCH(init_pvi_record, prec)
+return 0;
+}
+
+long get_iointr_info(int cmd, dbCommon *prec, IOSCANPVT *io)
+{
+    if(!prec->dpvt)
+        return -1;
+    Priv *priv=(Priv*)prec->dpvt;
+
+    *io = priv->block->scan;
+    return 0;
+}
+
+template<typename T, typename N>
+std::tr1::shared_ptr<T>
+assign(pvstructinRecord* prec, N& name)
+{
+    std::tr1::shared_ptr<T> fld(prec->val->getSubFieldT<T>(name));
+    prec->chg.set(fld->getFieldOffset());
+    return fld;
+}
+
+template<typename T>
+long read_pvi(pvstructinRecord* prec)
+{
+    if(!prec->dpvt)
+        return -1;
+    Priv *priv=(Priv*)prec->dpvt;
+
+    try {
+        Guard g(priv->psc->lock);
+
+        if(!priv->psc->isConnected()) {
+            int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
+            junk += 1;
+            return 0;
+        }
+
+        pvd::shared_vector<double> scratch;
+        const char *pfrom = &priv->block->data[0];
+
+        const size_t len = priv->block->data.size(); // available # of bytes
+        const size_t nelm = len/sizeof(T); // # of elements which can be accepted
+        // source step size in bytes, default to element size
+        const size_t step = priv->step!=0 ? priv->step : sizeof(T);
+        size_t dest = 0; // current dest element
+
+        scratch.resize(nelm);
+        double *pto = &scratch[0];
+
+        for(size_t src=priv->offset;
+            dest<nelm && src<len;
+            dest++, src+=step)
+        {
+            // endian fix and cast to target value type
+            T ival = bytes2val<T>(pfrom + src);
+            pto[dest] = ival;
+        }
+
+        scratch.resize(dest);
+
+        pvd::PVDoubleArrayPtr arr(prec->val->getSubFieldT<pvd::PVDoubleArray>("value"));
+        arr->replace(pvd::freeze(scratch));
+        prec->chg.set(arr->getFieldOffset());
+
+        setRecTimestamp(priv);
+
+        // TODO: in record support somehow?
+        assign<pvd::PVScalar>(prec, "timeStamp.secondsPastEpoch")->putFrom(prec->time.secPastEpoch + POSIX_TIME_AT_EPICS_EPOCH);
+        assign<pvd::PVScalar>(prec, "timeStamp.nanoseconds")->putFrom(prec->time.nsec);
+        assign<pvd::PVScalar>(prec, "timeStamp.userTag")->putFrom(prec->utag);
+
+        assign<pvd::PVScalar>(prec, "alarm.severity")->putFrom(prec->nsev);
+        assign<pvd::PVScalar>(prec, "alarm.status")->putFrom(prec->nsta);
+        assign<pvd::PVScalar>(prec, "alarm.message")->putFrom(std::string(prec->namsg));
+
+    }CATCH(read_pvi, prec)
+
+    return 0;
+}
+
+MAKEDSET(pvstructin, devPSCBlockInPVI16, &init_pvi_record<0>, &get_iointr_info, &read_pvi<epicsInt16>);
+MAKEDSET(pvstructin, devPSCBlockInPVI32, &init_pvi_record<0>, &get_iointr_info, &read_pvi<epicsInt32>);
+MAKEDSET(pvstructin, devPSCBlockInPVIF32, &init_pvi_record<0>, &get_iointr_info, &read_pvi<float>);
+MAKEDSET(pvstructin, devPSCBlockInPVIF64, &init_pvi_record<0>, &get_iointr_info, &read_pvi<double>);
+
+} // namespace
+
+#include <epicsExport.h>
+
+epicsExportAddress(dset, devPSCBlockInPVI16);
+epicsExportAddress(dset, devPSCBlockInPVI32);
+epicsExportAddress(dset, devPSCBlockInPVIF32);
+epicsExportAddress(dset, devPSCBlockInPVIF64);

--- a/coreApp/src/devPSCPVI.cpp
+++ b/coreApp/src/devPSCPVI.cpp
@@ -105,7 +105,7 @@ long read_pvi(pvstructinRecord* prec)
         // TODO: in record support somehow?
         assign<pvd::PVScalar>(prec, "timeStamp.secondsPastEpoch")->putFrom(prec->time.secPastEpoch + POSIX_TIME_AT_EPICS_EPOCH);
         assign<pvd::PVScalar>(prec, "timeStamp.nanoseconds")->putFrom(prec->time.nsec);
-        assign<pvd::PVScalar>(prec, "timeStamp.userTag")->putFrom(prec->utag);
+        assign<pvd::PVScalar>(prec, "timeStamp.userTag")->putFrom<pvd::uint64>(prec->utag);
 
         assign<pvd::PVScalar>(prec, "alarm.severity")->putFrom(prec->nsev);
         assign<pvd::PVScalar>(prec, "alarm.status")->putFrom(prec->nsta);

--- a/coreApp/src/devPSCReg.cpp
+++ b/coreApp/src/devPSCReg.cpp
@@ -112,7 +112,7 @@ void read_to_field(dbCommon *prec, Priv *priv, T* pfield)
     }
 
     if(!priv->psc->isConnected()) {
-        int junk = recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+        int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
         junk += 1;
     }
 
@@ -207,7 +207,7 @@ void write_from_field(dbCommon *prec, Priv *priv, const T* pfield)
     }
 
     if(!priv->psc->isConnected()) {
-        int junk = recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
+        int junk = recGblSetSevrMsg(prec, WRITE_ALARM, INVALID_ALARM, "No Conn");
         junk += 1;
     }
 

--- a/coreApp/src/devPSCReg.cpp
+++ b/coreApp/src/devPSCReg.cpp
@@ -211,10 +211,17 @@ void write_from_field(dbCommon *prec, Priv *priv, const T* pfield)
         junk += 1;
     }
 
-    T *pdata = (T*)&priv->block->data[priv->offset];
+    epics::pvData::shared_vector<char> scratch(epics::pvData::thaw(priv->block->data));
+    try {
+        T *pdata = (T*)&scratch[priv->offset];
 
-    *pdata = hton(*pfield);
-    return;
+        *pdata = hton(*pfield);
+
+        priv->block->data = epics::pvData::freeze(scratch);
+    }catch(...){
+        priv->block->data = epics::pvData::freeze(scratch);
+        throw;
+    }
 }
 
 // used for bo, mbbo, and mbboDirect

--- a/coreApp/src/devPSCReg.cpp
+++ b/coreApp/src/devPSCReg.cpp
@@ -24,6 +24,8 @@
 
 #include <menuConvert.h>
 
+#include "utilpvt.h"
+
 namespace {
 
 template<typename R> struct extra_init {static void op(R* prec){}};
@@ -46,7 +48,7 @@ long init_input(R* prec)
     assert(prec->inp.type==INST_IO);
     extra_init<R>::op(prec);
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->inp.value.instio.string, 0);
 
@@ -62,7 +64,7 @@ long init_rb(R* prec)
     assert(prec->inp.type==INST_IO);
     extra_init<R>::op(prec);
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->inp.value.instio.string, 1);
 
@@ -78,7 +80,7 @@ long init_output(R* prec)
     assert(prec->out.type==INST_IO);
     extra_init<R>::op(prec);
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->out.value.instio.string, 1);
 

--- a/coreApp/src/devPSCSV.cpp
+++ b/coreApp/src/devPSCSV.cpp
@@ -1,0 +1,158 @@
+/*************************************************************************\
+* Copyright (c) 2014 Brookhaven Science Assoc. as operator of
+      Brookhaven National Laboratory.
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "psc/devcommon.h"
+
+#include <stdio.h>
+#include <arpa/inet.h>
+
+#include <menuFtype.h>
+#include <svectorinRecord.h>
+
+namespace {
+
+template<int dir>
+long init_svi_record(svectorinRecord* prec)
+{
+    assert(prec->inp.type==INST_IO);
+    if(prec->ftvl!=menuFtypeDOUBLE) {
+        timefprintf(stderr, "%s: FTVL must be DOUBLE\n", prec->name);
+        return 0;
+    }
+    try {
+        std::auto_ptr<Priv> priv(new Priv(prec));
+
+        parse_link(priv.get(), prec->inp.value.instio.string, dir);
+
+        prec->dpvt = (void*)priv.release();
+
+    }CATCH(init_svi_record, prec)
+return 0;
+}
+
+template<int dir>
+long init_svi_record_bytes(svectorinRecord* prec)
+{
+    assert(prec->inp.type==INST_IO);
+    if(!(prec->ftvl==menuFtypeCHAR || prec->ftvl==menuFtypeUCHAR)) {
+        timefprintf(stderr, "%s: FTVL must be CHAR or UCHAR\n", prec->name);
+        return 0;
+    }
+    try {
+        std::auto_ptr<Priv> priv(new Priv(prec));
+
+        parse_link(priv.get(), prec->inp.value.instio.string, dir);
+
+        prec->dpvt = (void*)priv.release();
+
+    }CATCH(init_svi_record, prec)
+return 0;
+}
+
+long get_iointr_info(int cmd, dbCommon *prec, IOSCANPVT *io)
+{
+    if(!prec->dpvt)
+        return -1;
+    Priv *priv=(Priv*)prec->dpvt;
+
+    *io = priv->block->scan;
+    return 0;
+}
+
+template<typename T>
+long read_svi(svectorinRecord* prec)
+{
+    if(!prec->dpvt)
+        return -1;
+    Priv *priv=(Priv*)prec->dpvt;
+
+    try {
+        Guard g(priv->psc->lock);
+
+        if(!priv->psc->isConnected()) {
+            int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
+            junk += 1;
+            return 0;
+        }
+
+        epics::pvData::shared_vector<double> scratch(prec->nelm);
+        double *pto = &scratch[0];
+        const char *pfrom = &priv->block->data[0];
+
+        const size_t len = priv->block->data.size(); // available # of bytes
+        const size_t nelm = prec->nelm; // # of elements which can be accepted
+        // source step size in bytes, default to element size
+        const size_t step = priv->step!=0 ? priv->step : sizeof(T);
+        size_t dest = 0; // current dest element
+
+        for(size_t src=priv->offset;
+            dest<nelm && src<len;
+            dest++, src+=step)
+        {
+            // endian fix and cast to target value type
+            T ival = bytes2val<T>(pfrom + src);
+            pto[dest] = ival;
+        }
+
+        scratch.resize(dest);
+        prec->val = epics::pvData::static_shared_vector_cast<const void>(epics::pvData::freeze(scratch));
+
+        setRecTimestamp(priv);
+    }CATCH(read_svi, prec)
+
+    return 0;
+}
+
+long read_svi_bytes(svectorinRecord* prec)
+{
+    if(!prec->dpvt)
+        return -1;
+    Priv *priv=(Priv*)prec->dpvt;
+
+    try {
+        Guard g(priv->psc->lock);
+
+        if(!priv->psc->isConnected()) {
+            int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
+            junk += 1;
+            return 0;
+        }
+
+        epics::pvData::shared_vector<char> scratch(prec->nelm);
+        char *pto = (char*)&scratch[0];
+        const char *pfrom = &priv->block->data[0];
+
+        size_t len = priv->block->data.size();
+        if(len>=prec->nelm)
+            len=prec->nelm;
+
+        memcpy(pto, pfrom, len);
+
+        scratch.resize(len);
+        prec->val = epics::pvData::static_shared_vector_cast<const void>(epics::pvData::freeze(scratch));
+
+        setRecTimestamp(priv);
+    }CATCH(read_svi_bytes, prec)
+
+    return 0;
+}
+
+MAKEDSET(svectorin, devPSCBlockInSVI8, &init_svi_record_bytes<0>, &get_iointr_info, &read_svi_bytes);
+MAKEDSET(svectorin, devPSCBlockInSVI16, &init_svi_record<0>, &get_iointr_info, &read_svi<epicsInt16>);
+MAKEDSET(svectorin, devPSCBlockInSVI32, &init_svi_record<0>, &get_iointr_info, &read_svi<epicsInt32>);
+MAKEDSET(svectorin, devPSCBlockInSVIF32, &init_svi_record<0>, &get_iointr_info, &read_svi<float>);
+MAKEDSET(svectorin, devPSCBlockInSVIF64, &init_svi_record<0>, &get_iointr_info, &read_svi<double>);
+
+} // namespace
+
+#include <epicsExport.h>
+
+epicsExportAddress(dset, devPSCBlockInSVI8);
+epicsExportAddress(dset, devPSCBlockInSVI16);
+epicsExportAddress(dset, devPSCBlockInSVI32);
+epicsExportAddress(dset, devPSCBlockInSVIF32);
+epicsExportAddress(dset, devPSCBlockInSVIF64);

--- a/coreApp/src/devPSCSingle.cpp
+++ b/coreApp/src/devPSCSingle.cpp
@@ -64,10 +64,7 @@ void received_block(void* raw, Block* block)
 
     bool alreadyQueued = !priv->syncData.empty();
 
-    priv->syncData.resize(block->data.size());
-    std::copy(priv->block->data.begin(),
-              priv->block->data.end(),
-              priv->syncData.begin());
+    priv->syncData = priv->block->data;
 
     if(!alreadyQueued)
         callbackRequest(&priv->syncCB);

--- a/coreApp/src/devPSCSingle.cpp
+++ b/coreApp/src/devPSCSingle.cpp
@@ -21,6 +21,8 @@
 
 #include <menuConvert.h>
 
+#include "utilpvt.h"
+
 namespace {
 
 template<typename R> struct extra_init {static void op(R* prec){}};
@@ -90,7 +92,7 @@ long init_output(R* prec)
     assert(prec->out.type==INST_IO);
     extra_init<R>::op(prec);
     try {
-        std::auto_ptr<SinglePriv> priv(new SinglePriv(prec));
+        psc::auto_ptr<SinglePriv> priv(new SinglePriv(prec));
 
         RecInfo info((dbCommon*)prec);
 

--- a/coreApp/src/devPSCString.cpp
+++ b/coreApp/src/devPSCString.cpp
@@ -62,7 +62,7 @@ long read_si(stringinRecord* prec)
         Guard(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+            recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
             return 0;
         }
 
@@ -95,7 +95,7 @@ long write_so(stringoutRecord* prec)
         Guard(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
+            recGblSetSevrMsg(prec, WRITE_ALARM, INVALID_ALARM, "No Conn");
             return 0;
         }
 

--- a/coreApp/src/devPSCString.cpp
+++ b/coreApp/src/devPSCString.cpp
@@ -103,9 +103,11 @@ long write_so(stringoutRecord* prec)
 
         priv->psc->queueSend(priv->block, (void*)&prec->val[0], len);
 
-        priv->block->data.resize(len);
+        epics::pvData::shared_vector<char> temp(len);
 
-        memcpy(&priv->block->data[0], prec->val, len);
+        memcpy(&temp[0], prec->val, len);
+
+        priv->block->data = epics::pvData::freeze(temp);
     }CATCH(write_so, prec)
 
     return 0;

--- a/coreApp/src/devPSCString.cpp
+++ b/coreApp/src/devPSCString.cpp
@@ -10,13 +10,15 @@
 #include <stringinRecord.h>
 #include <stringoutRecord.h>
 
+#include "utilpvt.h"
+
 namespace {
 
 long init_si_record(stringinRecord* prec)
 {
     assert(prec->inp.type==INST_IO);
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->inp.value.instio.string, 0);
 
@@ -30,7 +32,7 @@ long init_so_record(stringoutRecord* prec)
 {
     assert(prec->out.type==INST_IO);
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->out.value.instio.string, 1);
 

--- a/coreApp/src/devPSCWf.cpp
+++ b/coreApp/src/devPSCWf.cpp
@@ -123,7 +123,7 @@ long read_wf_bytes(waveformRecord* prec)
         }
 
         char *pto = (char*)prec->bptr;
-        char *pfrom = &priv->block->data[0];
+        const char *pfrom = &priv->block->data[0];
 
         size_t len = priv->block->data.size();
         if(len>=prec->nelm)

--- a/coreApp/src/devPSCWf.cpp
+++ b/coreApp/src/devPSCWf.cpp
@@ -76,7 +76,7 @@ long read_wf(waveformRecord* prec)
         Guard g(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            int junk = recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+            int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
             junk += 1;
             return 0;
         }
@@ -117,7 +117,7 @@ long read_wf_bytes(waveformRecord* prec)
         Guard g(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            int junk = recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+            int junk = recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
             junk += 1;
             return 0;
         }
@@ -161,7 +161,7 @@ long write_wf(waveformRecord* prec)
         Guard g(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            (void)recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+            (void)recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
             return 0;
         }
 
@@ -180,7 +180,7 @@ long write_wf_bytes(waveformRecord* prec)
         Guard g(priv->psc->lock);
 
         if(!priv->psc->isConnected()) {
-            (void)recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+            (void)recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "No Conn");
             return 0;
         }
 

--- a/coreApp/src/devPSCWf.cpp
+++ b/coreApp/src/devPSCWf.cpp
@@ -13,6 +13,8 @@
 #include <menuFtype.h>
 #include <waveformRecord.h>
 
+#include "utilpvt.h"
+
 namespace {
 
 template<int dir>
@@ -24,7 +26,7 @@ long init_wf_record(waveformRecord* prec)
         return 0;
     }
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->inp.value.instio.string, dir);
 
@@ -43,7 +45,7 @@ long init_wf_record_bytes(waveformRecord* prec)
         return 0;
     }
     try {
-        std::auto_ptr<Priv> priv(new Priv(prec));
+        psc::auto_ptr<Priv> priv(new Priv(prec));
 
         parse_link(priv.get(), prec->inp.value.instio.string, dir);
 

--- a/coreApp/src/devcommon.cpp
+++ b/coreApp/src/devcommon.cpp
@@ -55,6 +55,16 @@ void parse_link(Priv* priv, const char* link, int direction)
             else
                 priv->timeFromBlock = true;
         }
+
+        const char *tagoffset = info.get("TagFromBlock");
+        if(tagoffset) {
+            std::istringstream tsstrm(tagoffset);
+            tsstrm >> priv->tagoffset;
+            if(tsstrm.fail())
+                timefprintf(stderr, "%s: Error processing time offset '%s'\n", priv->prec->name, tagoffset);
+            else
+                priv->tagFromBlock = true;
+        }
     }
 
     Guard(priv->psc->lock);
@@ -121,6 +131,15 @@ void setRecTimestamp(Priv *priv)
     }
 
     priv->prec->time = result;
+
+    if(priv->tagFromBlock &&
+            priv->block &&
+            priv->block->data.size() >= (priv->tagoffset+4))
+    {
+        epicsUInt32 raw = *(epicsUInt32*)&priv->block->data[priv->tagoffset];
+
+        priv->prec->utag = ntohl(raw);
+    }
 }
 
 RecInfo::RecInfo(const char *recname)

--- a/coreApp/src/devcommon.cpp
+++ b/coreApp/src/devcommon.cpp
@@ -70,7 +70,6 @@ void parse_link(Priv* priv, const char* link, int direction)
                 priv->prec->name, block, name.c_str());
         throw std::runtime_error("PSC can't get block #");
     }
-    return;
 }
 
 namespace {

--- a/coreApp/src/evbase.cpp
+++ b/coreApp/src/evbase.cpp
@@ -17,12 +17,10 @@
 std::tr1::weak_ptr<EventBase> EventBase::last_base;
 
 EventBase::EventBase()
-    :epicsThreadRunable()
-    ,base(NULL)
+    :base(NULL)
     ,runner(*this, "eventbase",
             epicsThreadGetStackSize(epicsThreadStackSmall),
             epicsThreadPriorityHigh)
-    ,lock()
     ,running(false)
 {
     base = event_base_new();

--- a/coreApp/src/psc.cpp
+++ b/coreApp/src/psc.cpp
@@ -196,6 +196,11 @@ void PSC::start_reconnect()
 
     connected = false;
     timer_active = true;
+
+    for(block_map::iterator it=recv_blocks.begin(), end=recv_blocks.end(); it!=end; ++it)
+    {
+        scanIoRequest(it->second->scan);
+    }
 }
 
 /* entry point for re-connect timer */

--- a/coreApp/src/psc.cpp
+++ b/coreApp/src/psc.cpp
@@ -335,12 +335,13 @@ void PSC::recvdata()
                 if(PSCDebug>2)
                     timefprintf(stderr, "%s: Process message %u\n", name.c_str(), header);
 
-                bodyblock->data.reserve(bodylen);
-                bodyblock->data.resize(bodylen);
+                epics::pvData::shared_vector<char> temp(bodylen);
 
-                evbuffer_remove(buf, &bodyblock->data[0], bodylen);
+                evbuffer_remove(buf, &temp[0], bodylen);
                 scanIoRequest(bodyblock->scan);
                 bodyblock->listeners(bodyblock);
+
+                bodyblock->data = epics::pvData::freeze(temp);
 
             } else {
                 /* ignore valid, but uninteresting message body */

--- a/coreApp/src/psc/devcommon.h
+++ b/coreApp/src/psc/devcommon.h
@@ -68,10 +68,13 @@ struct Priv
     long step;
 
     bool timeFromBlock;
+    bool tagFromBlock;
     unsigned long tsoffset;
+    unsigned long tagoffset;
 
     template<class R>
-    Priv(R*pr) : prec((dbCommon*)pr), psc(0), bid(0), block(0), offset(0), step(0), timeFromBlock(false) {}
+    Priv(R*pr) : prec((dbCommon*)pr), psc(0), bid(0), block(0), offset(0), step(0),
+        timeFromBlock(false), tagFromBlock(false) {}
 };
 
 void parse_link(Priv* priv, const char* link, int direction);

--- a/coreApp/src/psc/device.h
+++ b/coreApp/src/psc/device.h
@@ -27,6 +27,8 @@
 #include <event2/bufferevent.h>
 #include <event2/buffer.h>
 
+#include <pv/sharedVector.h>
+
 #include "cblist.h"
 
 #if __cplusplus<201103L
@@ -78,7 +80,7 @@ struct Block
     PSCBase& psc;
     const epicsUInt16 code;
 
-    typedef std::vector<char> data_t;
+    typedef epics::pvData::shared_vector<const char> data_t;
     data_t data;
 
     bool queued;

--- a/coreApp/src/psc/device.h
+++ b/coreApp/src/psc/device.h
@@ -29,6 +29,15 @@
 
 #include "cblist.h"
 
+#if __cplusplus<201103L
+#  ifndef override
+#    define override
+#  endif
+#  ifndef final
+#    define final
+#  endif
+#endif
+
 extern "C" {
 extern int PSCDebug;
 extern int PSCInactivityTime;
@@ -187,12 +196,12 @@ public:
         unsigned int timeoutmask);
     virtual ~PSC();
 
-    virtual void queueSend(Block*, const void*, epicsUInt32);
+    virtual void queueSend(Block*, const void*, epicsUInt32) override;
 
-    virtual void flushSend();
-    virtual void forceReConnect();
+    virtual void flushSend() override;
+    virtual void forceReConnect() override;
 
-    virtual void report(int lvl);
+    virtual void report(int lvl) override;
 private:
 
     // RX message decoding
@@ -204,13 +213,13 @@ private:
 
     void sendblock(Block*);
 
-    virtual void connect();
+    virtual void connect() override;
     void start_reconnect();
 
     // libevent callbacks
     void eventcb(short);
     void recvdata();
-    virtual void stop();
+    virtual void stop() override;
     void reconnect();
 
     static void bev_eventcb(bufferevent*,short,void*);
@@ -228,10 +237,10 @@ public:
            unsigned int timeoutmask);
     virtual ~PSCUDP();
 
-    virtual void queueSend(Block*, const void*, epicsUInt32);
+    virtual void queueSend(Block*, const void*, epicsUInt32) override;
 
-    virtual void flushSend();
-    virtual void forceReConnect();
+    virtual void flushSend() override;
+    virtual void forceReConnect() override;
 
 private:
     sockaddr_in ep;
@@ -243,7 +252,7 @@ private:
     std::list<buffer_t> txqueue;
     buffer_t rxscratch;
 
-    virtual void connect();
+    virtual void connect() override;
 
     void senddata(short evt);
     void recvdata(short evt);

--- a/coreApp/src/psc/evbase.h
+++ b/coreApp/src/psc/evbase.h
@@ -8,10 +8,10 @@
 #ifndef EVBASE_H
 #define EVBASE_H
 
-#include <tr1/memory>
-
 #include <epicsThread.h>
 #include <epicsMutex.h>
+
+#include <pv/sharedPtr.h>
 
 #include "util.h"
 

--- a/coreApp/src/pscCore.dbd
+++ b/coreApp/src/pscCore.dbd
@@ -41,6 +41,11 @@ device(svectorin, INST_IO, devPSCBlockInSVI32,  "PSC Block I32 In")
 device(svectorin, INST_IO, devPSCBlockInSVIF32,  "PSC Block F32 In")
 device(svectorin, INST_IO, devPSCBlockInSVIF64,  "PSC Block F64 In")
 
+device(pvstructin, INST_IO, devPSCBlockInPVI16,  "PSC Block I16 In")
+device(pvstructin, INST_IO, devPSCBlockInPVI32,  "PSC Block I32 In")
+device(pvstructin, INST_IO, devPSCBlockInPVIF32,  "PSC Block F32 In")
+device(pvstructin, INST_IO, devPSCBlockInPVIF64,  "PSC Block F64 In")
+
 #  Link: "@pscname block# tx|rx"
 device(longin, INST_IO, devPSCBlockCountLi, "PSC Block Msg Count")
 

--- a/coreApp/src/pscCore.dbd
+++ b/coreApp/src/pscCore.dbd
@@ -34,6 +34,13 @@ device(waveform, INST_IO, devPSCBlockInWfF32,  "PSC Block F32 In")
 device(waveform, INST_IO, devPSCBlockOutWfF32, "PSC Block F32 Out")
 device(waveform, INST_IO, devPSCBlockInWfF64,  "PSC Block F64 In")
 device(waveform, INST_IO, devPSCBlockOutWfF64, "PSC Block F64 Out")
+
+device(svectorin, INST_IO, devPSCBlockInSVI8,  "PSC Block I8 In")
+device(svectorin, INST_IO, devPSCBlockInSVI16,  "PSC Block I16 In")
+device(svectorin, INST_IO, devPSCBlockInSVI32,  "PSC Block I32 In")
+device(svectorin, INST_IO, devPSCBlockInSVIF32,  "PSC Block F32 In")
+device(svectorin, INST_IO, devPSCBlockInSVIF64,  "PSC Block F64 In")
+
 #  Link: "@pscname block# tx|rx"
 device(longin, INST_IO, devPSCBlockCountLi, "PSC Block Msg Count")
 

--- a/coreApp/src/pscbase.cpp
+++ b/coreApp/src/pscbase.cpp
@@ -154,7 +154,8 @@ void setPSCSendBlockSize(const char* name, int bid, int size)
         Block *block = psc->getSend(bid);
         if(!block)
             throw std::runtime_error("Can't select PSC Block");
-        block->data.resize(size, 0);
+        epics::pvData::shared_vector<char> temp(size, 0);
+        block->data = epics::pvData::freeze(temp);
         timefprintf(stderr, "Set PSC '%s' send block %d size to %lu bytes\n",
                 name, bid, (unsigned long)block->data.size());
     }catch(std::exception& e){

--- a/coreApp/src/pscbase.cpp
+++ b/coreApp/src/pscbase.cpp
@@ -20,6 +20,8 @@
 
 #include <epicsExit.h>
 
+#include "utilpvt.h"
+
 int PSCDebug = 1;
 int PSCInactivityTime = 5;
 int PSCMaxSendBuffer = 1024 * 1024;
@@ -70,7 +72,7 @@ Block* PSCBase::getSend(epicsUInt16 block)
     block_map::const_iterator it = send_blocks.find(block);
     if(it!=send_blocks.end())
         return it->second;
-    std::auto_ptr<Block> ret(new Block(this, block));
+    psc::auto_ptr<Block> ret(new Block(this, block));
     send_blocks[block] = ret.get();
     return ret.release();
 }
@@ -80,7 +82,7 @@ Block* PSCBase::getRecv(epicsUInt16 block)
     block_map::const_iterator it = recv_blocks.find(block);
     if(it!=recv_blocks.end())
         return it->second;
-    std::auto_ptr<Block> ret(new Block(this, block));
+    psc::auto_ptr<Block> ret(new Block(this, block));
     recv_blocks[block] = ret.get();
     return ret.release();
 }

--- a/coreApp/src/pscudp.cpp
+++ b/coreApp/src/pscudp.cpp
@@ -198,8 +198,10 @@ void PSCUDP::recvdata(short evt)
             }
             bodyblock.count++;
 
-            bodyblock.data.resize(bodylen);
-            memcpy(&bodyblock.data[0], hbuf+8, bodylen);
+            epics::pvData::shared_vector<char> temp(bodylen);
+
+            memcpy(&temp[0], hbuf+8, bodylen);
+            bodyblock.data = epics::pvData::freeze(temp);
 
             scanIoRequest(bodyblock.scan);
             bodyblock.listeners(&bodyblock);

--- a/coreApp/src/utilpvt.h
+++ b/coreApp/src/utilpvt.h
@@ -1,0 +1,17 @@
+#ifndef UTILPVT_H
+#define UTILPVT_H
+
+#include <memory>
+
+namespace psc {
+#if __cplusplus>=201103L
+template<typename T>
+using auto_ptr = std::unique_ptr<T>;
+#define PTRMOVE(AUTO) std::move(AUTO)
+#else
+using std::auto_ptr;
+#define PTRMOVE(AUTO) (AUTO)
+#endif
+}
+
+#endif /* UTILPVT_H */

--- a/demoApp/Db/Makefile
+++ b/demoApp/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/demoApp/Makefile
+++ b/demoApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/demoApp/src/Makefile
+++ b/demoApp/src/Makefile
@@ -1,0 +1,43 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+#=============================
+# Build the IOC application
+
+PROD_IOC = pscdemo
+# demo.dbd will be created and installed
+DBD += pscdemo.dbd
+
+# demo.dbd will be made up from these files:
+pscdemo_DBD += base.dbd
+pscdemo_DBD += pscCore.dbd
+pscdemo_DBD += PVAServerRegister.dbd
+pscdemo_DBD += qsrv.dbd
+
+pscdemo_LIBS += pscCore
+pscdemo_LIBS += qsrv
+pscdemo_LIBS += $(EPICS_BASE_PVA_CORE_LIBS)
+
+# pscdemo_registerRecordDeviceDriver.cpp derives from pscdemo.dbd
+pscdemo_SRCS += pscdemo_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+pscdemo_SRCS_DEFAULT += demoMain.cpp
+pscdemo_SRCS_vxWorks += -nil-
+
+# Finally link to the EPICS Base libraries
+pscdemo_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+pscdemo_SYS_LIBS += event_core event_extra
+pscdemo_SYS_LIBS_Linux += event_pthreads
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/demoApp/src/Makefile
+++ b/demoApp/src/Makefile
@@ -14,9 +14,9 @@ DBD += pscdemo.dbd
 
 # demo.dbd will be made up from these files:
 pscdemo_DBD += base.dbd
+pscdemo_DBD += qsrv.dbd
 pscdemo_DBD += pscCore.dbd
 pscdemo_DBD += PVAServerRegister.dbd
-pscdemo_DBD += qsrv.dbd
 
 pscdemo_LIBS += pscCore
 pscdemo_LIBS += qsrv

--- a/demoApp/src/demoMain.cpp
+++ b/demoApp/src/demoMain.cpp
@@ -1,0 +1,23 @@
+/* demoMain.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/iocBoot/iocpscsim/st.cmd
+++ b/iocBoot/iocpscsim/st.cmd
@@ -1,11 +1,11 @@
-#!../../bin/linux-x86/psc
+#!../../bin/linux-x86_64-debug/pscdemo
 
 ## You may have to change psc to something else
 ## everywhere it appears in this file
 
 ## Register all support components
-dbLoadDatabase("../../dbd/psc.dbd",0,0)
-psc_registerRecordDeviceDriver(pdbbase) 
+dbLoadDatabase("../../dbd/pscdemo.dbd",0,0)
+pscdemo_registerRecordDeviceDriver(pdbbase) 
 
 ## Load record instances
 dbLoadRecords("../../db/pscsim.db","P=test:")

--- a/iocBoot/iocutag/demo.bob
+++ b/iocBoot/iocutag/demo.bob
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display version="2.0.0">
+  <name>Display</name>
+  <macros>
+    <P>TST:</P>
+  </macros>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button</name>
+    <pv_name>pva://$(P)BEAM</pv_name>
+    <x>10</x>
+    <y>10</y>
+    <width>80</width>
+    <labels_from_pv>true</labels_from_pv>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_1</name>
+    <pv_name>pva://$(P)SRC</pv_name>
+    <x>10</x>
+    <y>50</y>
+    <width>80</width>
+    <labels_from_pv>true</labels_from_pv>
+  </widget>
+  <widget type="bool_button" version="2.0.0">
+    <name>Boolean Button_2</name>
+    <pv_name>pva://$(P)AUTO</pv_name>
+    <x>10</x>
+    <y>90</y>
+    <width>80</width>
+    <labels_from_pv>true</labels_from_pv>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update</name>
+    <pv_name>pva://$(P)CNT</pv_name>
+    <x>190</x>
+    <y>10</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update_2</name>
+    <pv_name>pva://$(P)CNT.VAL{"utag":{"M":1,"V":1}}</pv_name>
+    <x>190</x>
+    <y>70</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update_4</name>
+    <pv_name>pva://$(P)CNT.{"utag":{"M":3,"V":3}}</pv_name>
+    <x>190</x>
+    <y>130</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update_5</name>
+    <pv_name>pva://$(P)CNT.{"utag":{"M":3,"V":1}}</pv_name>
+    <x>190</x>
+    <y>100</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>Text Update_6</name>
+    <pv_name>pva://$(P)CNT.{"utag":{"M":1,"V":0}}</pv_name>
+    <x>190</x>
+    <y>40</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Always</text>
+    <x>120</x>
+    <y>10</y>
+    <width>70</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_1</name>
+    <text>Beam Off</text>
+    <x>120</x>
+    <y>40</y>
+    <width>70</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_2</name>
+    <text>Beam On</text>
+    <x>120</x>
+    <y>70</y>
+    <width>70</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_3</name>
+    <text>On Src A</text>
+    <x>120</x>
+    <y>100</y>
+    <width>70</width>
+    <height>30</height>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_4</name>
+    <text>On Src B</text>
+    <x>120</x>
+    <y>130</y>
+    <width>70</width>
+    <height>30</height>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>X/Y Plot_3</name>
+    <x>20</x>
+    <y>370</y>
+    <width>1150</width>
+    <height>290</height>
+    <title>All updates</title>
+    <x_axis>
+      <title>X</title>
+      <autoscale>true</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>100.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>false</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>512.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>raw</name>
+        <x_pv></x_pv>
+        <y_pv>pva://$(P)WF.VAL{"arr":{}}</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>min</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/min</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="255" green="0" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>max</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/max</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="255" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>mean</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{}}/mean</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="170" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>1</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>Text Entry</name>
+    <pv_name>pva://$(P)WF:STAT.DEC</pv_name>
+    <x>380</x>
+    <y>20</y>
+    <width>50</width>
+    <height>30</height>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>X/Y Plot_4</name>
+    <x>20</x>
+    <y>180</y>
+    <width>570</width>
+    <height>180</height>
+    <title>Beam On Src A</title>
+    <x_axis>
+      <title>X</title>
+      <autoscale>true</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>100.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>false</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>512.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>raw</name>
+        <x_pv></x_pv>
+        <y_pv>pva://$(P)WF.VAL{"arr":{},"utag":{"M":3,"V":1}}</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>min</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/min</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="255" green="0" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>max</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/max</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="255" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>mean</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":1}}/mean</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="170" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>1</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="xyplot" version="2.0.0">
+    <name>X/Y Plot_5</name>
+    <x>600</x>
+    <y>170</y>
+    <width>570</width>
+    <height>180</height>
+    <title>Beam On Src B</title>
+    <x_axis>
+      <title>X</title>
+      <autoscale>true</autoscale>
+      <log_scale>false</log_scale>
+      <minimum>0.0</minimum>
+      <maximum>100.0</maximum>
+      <show_grid>false</show_grid>
+      <title_font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        </font>
+      </title_font>
+      <scale_font>
+        <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+        </font>
+      </scale_font>
+      <visible>true</visible>
+    </x_axis>
+    <y_axes>
+      <y_axis>
+        <title>Y</title>
+        <autoscale>false</autoscale>
+        <log_scale>false</log_scale>
+        <minimum>0.0</minimum>
+        <maximum>512.0</maximum>
+        <show_grid>false</show_grid>
+        <title_font>
+          <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+          </font>
+        </title_font>
+        <scale_font>
+          <font name="Default" family="Liberation Sans" style="REGULAR" size="14.0">
+          </font>
+        </scale_font>
+        <visible>true</visible>
+      </y_axis>
+    </y_axes>
+    <traces>
+      <trace>
+        <name>raw</name>
+        <x_pv></x_pv>
+        <y_pv>pva://$(P)WF.VAL{"arr":{},"utag":{"M":3,"V":3}}</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>min</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/min</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="255" green="0" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>max</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/max</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="0" green="255" blue="0">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>0</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+      <trace>
+        <name>mean</name>
+        <x_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/idx</x_pv>
+        <y_pv>pva://$(P)WF:STAT.VAL{"arr":{},"utag":{"M":3,"V":3}}/mean</y_pv>
+        <err_pv></err_pv>
+        <axis>0</axis>
+        <trace_type>1</trace_type>
+        <color>
+          <color red="170" green="0" blue="255">
+          </color>
+        </color>
+        <line_width>1</line_width>
+        <line_style>0</line_style>
+        <point_type>1</point_type>
+        <point_size>10</point_size>
+        <visible>true</visible>
+      </trace>
+    </traces>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label_5</name>
+    <text>Decimation</text>
+    <x>260</x>
+    <y>20</y>
+    <width>110</width>
+    <height>30</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <vertical_alignment>1</vertical_alignment>
+  </widget>
+  <widget type="combo" version="2.0.0">
+    <name>Combo Box</name>
+    <pv_name>TST:WF.SCAN</pv_name>
+    <x>330</x>
+    <y>90</y>
+    <width>130</width>
+  </widget>
+</display>

--- a/iocBoot/iocutag/sim.db
+++ b/iocBoot/iocutag/sim.db
@@ -1,0 +1,79 @@
+
+# sim reading
+
+record(svectorin, "$(P)WF") {
+    field(DTYP, "PSC Block I32 In")
+    field(INP , "@$(NAME) 0 12") # block zero, skip 12 bytes
+    field(SCAN, "I/O Intr")
+    field(FTVL, "DOUBLE")
+    field(NELM, "1024")
+    field(TSE , "-2")
+    field(FLNK, "$(P)WF:STAT")
+    info("TimeFromBlock", "0") # time from device block0[0:7]
+    info("TagFromBlock", "8")  # utag from device block0[8:11]
+}
+
+record(statBin, "$(P)WF:STAT") {
+    field(INP , "$(P)WF NPP")
+    field(TSEL, "$(P)WF.TIME NPP")
+    field(FLNK, "$(P)CNT")
+    field(DEC , "16")
+}
+
+record(pvstructin, "$(P)WF2") {
+    field(DTYP, "PSC Block I32 In")
+    field(INP , "@$(NAME) 0 12") # block zero, skip 12 bytes
+    field(SCAN, "I/O Intr")
+    field(TSE , "-2")
+    field(FLNK, "$(P)CNT")
+    info("TimeFromBlock", "0") # time from device block0[0:7]
+    info("TagFromBlock", "8")  # utag from device block0[8:11]
+}
+
+# sim control
+record(calc, "$(P)CNT") {
+    field(CALC, "VAL+1")
+    field(TSEL, "$(P)WF.TIME") # also copies UTAG
+}
+
+record(bo, "$(P)BEAM") {
+    field(ZNAM, "Off")
+    field(ONAM, "On")
+    field(OUT , "$(P)CTRL.B0 PP")
+    field(VAL , "0")
+}
+
+record(bo, "$(P)SRC") {
+    field(ZNAM, "A")
+    field(ONAM, "B")
+    field(OUT , "$(P)CTRL.B1 PP")
+    field(VAL , "0")
+}
+
+record(bo, "$(P)AUTO") {
+    field(ZNAM, "Manual")
+    field(ONAM, "Auto")
+    field(OUT , "$(P)CTRL.B2 PP")
+    field(VAL , "0")
+}
+
+record(mbboDirect, "$(P)CTRL") {
+    field(DTYP, "PSC Reg")
+    field(OUT , "@$(NAME) 1")
+    field(VAL , "0")
+    field(FLNK, "$(P)send1_")
+}
+
+record(longout, "$(P)send1_") {
+    field(DTYP, "PSC Ctrl Send")
+    field(OUT , "@$(NAME)")
+    field(VAL , "1")
+    field(FLNK, "$(P)send_")
+}
+
+record(bo, "$(P)send_") {
+    field(DTYP, "PSC Ctrl Send All")
+    field(OUT , "@$(NAME)")
+    field(ZNAM, "Send")
+    field(ONAM, "Send")
+}

--- a/iocBoot/iocutag/sim.py
+++ b/iocBoot/iocutag/sim.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import time
+import struct
+import logging
+import asyncio
+
+from numpy.random import randn
+import numpy as np
+
+_log = logging.getLogger(__name__)
+
+def getargs():
+    from argparse import ArgumentParser
+    P = ArgumentParser()
+    P.add_argument('--bind', default='0.0.0.0:5678')
+    P.add_argument('-v', '--verbose', action='store_const', default=logging.INFO, const=logging.DEBUG)
+    return P
+
+class Server:
+    def __init__(self):
+        self.clients = {}
+        # bit 0 - beam on
+        # bit 1 - source A/B
+        # bit 2 - auto toggle source
+        self.tag = 0
+
+        self._tick = asyncio.ensure_future(self.tick())
+
+    async def tick(self):
+        try:
+            while True:
+                if self.tag&4:
+                    self.tag ^= 2 # auto toggle source
+
+                await asyncio.sleep(0.1)
+                sec, nsec = divmod(time.time(), 1.0)
+                sec, nsec = int(sec), int(nsec*1e9)
+
+                #_log.debug('Tick')
+
+                T = np.linspace(0.0, 10.0, 1024)
+                V = randn(*T.shape)*2.0
+
+                amp = 0.0
+                mean = 0.0
+                std = 1.0
+
+                if self.tag&1:
+                    # beam on
+                    if self.tag&2:
+                        # source B
+                        amp = 10.0
+                        mean = 3.0
+                        std = 1.0
+                    else:
+                        # source A
+                        amp = 15.0
+                        mean = 6.6
+                        std = 1.5
+
+                amp += randn()/5.0
+                mean += randn()/5.0
+                std += randn()/5.0
+
+                V += amp * np.exp(-(T-mean)**2/(2*std**2))
+
+                V = (V*20.0).astype('>i4')
+
+                M = [None, struct.pack('>III', sec, nsec, self.tag), V.tobytes()]
+
+                M[0] = struct.pack('>2sHI', b'PS', 0, len(M[1])+len(M[2]))
+                M = b''.join(M)
+
+                for sock in self.clients.values():
+                    sock.write(M)
+                for peer, sock in self.clients.items():
+                    try:
+                        await asyncio.wait_for(sock.drain(), 0.5)
+                    except asyncio.TimeoutError:
+                        _log.error('%s TX stalled', peer)
+                        sock.close()
+
+        except:
+            _log.exception('Tick fails')
+
+    async def handle(self, reader, writer):
+        peer = writer.get_extra_info('peername')
+        _log.info('%s connects', peer)
+        try:
+            self.clients[peer] = writer
+
+            while True:
+                H = await reader.readexactly(8)
+                PS, msgid, blen = struct.unpack('>2sHI', H)
+                if PS!=b'PS':
+                    raise RuntimeError('Corrupt header '+repr(H))
+                B = await reader.readexactly(blen)
+                _log.debug("%s sends %d %s", peer, msgid, B)
+
+                if msgid==1: # set TAG
+                    self.tag, = struct.unpack('>I', B[:4])
+                    _log.info('%s TAG=%x', peer, self.tag)
+
+        except Exception as e:
+            _log.exception('%s error', peer)
+        finally:
+            _log.info('%s disconnects', peer)
+            self.clients.pop(peer)
+
+async def main(args):
+    iface, _sep, port = args.bind.partition(':')
+    serv = Server()
+
+    listener = await asyncio.start_server(serv.handle, iface, int(port or '5678'))
+
+    _log.info('Serving from %s', listener.sockets[0].getsockname())
+    async with listener:
+        await listener.serve_forever()
+
+if __name__=='__main__':
+    args = getargs().parse_args()
+    logging.basicConfig(level=args.verbose)
+    asyncio.run(main(args))

--- a/iocBoot/iocutag/st.cmd
+++ b/iocBoot/iocutag/st.cmd
@@ -1,0 +1,12 @@
+#!../../bin/linux-x86_64-debug/pscdemo
+
+## Register all support components
+dbLoadDatabase("../../dbd/pscdemo.dbd",0,0)
+pscdemo_registerRecordDeviceDriver(pdbbase) 
+
+dbLoadRecords("../../db/psc-ctrl.db","P=TST:,NAME=thesim")
+dbLoadRecords("sim.db","P=TST:,NAME=thesim")
+createPSC("thesim", "localhost", 5678, 1)
+setPSCSendBlockSize("thesim", 1, 4)
+
+iocInit()

--- a/sigApp/src/Makefile
+++ b/sigApp/src/Makefile
@@ -5,6 +5,8 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+USR_CPPFLAGS += -I$(TOP)/coreApp/src
+
 LIBRARY_IOC = pscSig
 
 DBD += pscSig.dbd

--- a/testApp/Makefile
+++ b/testApp/Makefile
@@ -5,6 +5,8 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+USR_CPPFLAGS += -I$(TOP)/coreApp/src
+
 PROD_LIBS += Com
 
 TESTPROD_HOST += testValues


### PR DESCRIPTION
Make use of new features of epics-base/epics-base#71, mdavidsaver/epics-base#1, and https://github.com/mdavidsaver/pva2pva/pull/3.

Change internal buffering to use `shared_vector<>` and add device support for `svectorinRecord` and (less usefully) `pvstructinRecord` to move array data in w/o copying.